### PR TITLE
#fix: set offset reset config from configuration

### DIFF
--- a/src/main/scala/org/sunbird/obsrv/connector/KafkaConnector.scala
+++ b/src/main/scala/org/sunbird/obsrv/connector/KafkaConnector.scala
@@ -77,6 +77,15 @@ class KafkaConnectorSource extends IConnectorSource {
     properties
   }
 
+  private def offsetResetStrategy(config: Config): OffsetResetStrategy = {
+    val value = if (config.hasPath("source_kafka_auto_offset_reset")) config.getString("source_kafka_auto_offset_reset") else "earliest"
+    value.toLowerCase match {
+      case "latest" => OffsetResetStrategy.LATEST
+      case "none"   => OffsetResetStrategy.NONE
+      case _         => OffsetResetStrategy.EARLIEST
+    }
+  }
+
   private def kafkaSource(config: Config): KafkaSource[String] = {
     val dataFormat = config.getString("source_data_format")
     if(!"json".equals(config.getString("source_data_format"))) {
@@ -86,7 +95,7 @@ class KafkaConnectorSource extends IConnectorSource {
       .setTopics(config.getString("source_kafka_topic"))
       .setDeserializer(new StringDeserializationSchema)
       .setProperties(kafkaConsumerProperties(config))
-      .setStartingOffsets(OffsetsInitializer.committedOffsets(OffsetResetStrategy.EARLIEST))
+      .setStartingOffsets(OffsetsInitializer.committedOffsets(offsetResetStrategy(config)))
       .build()
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kafka connector now supports configurable offset reset strategy via configuration settings, replacing the previous hard-coded behavior. Users can specify whether to resume from the latest, earliest, or no offsets when connecting to Kafka sources, enabling more flexible data consumption patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->