### PR TITLE
#fix: vulnerability fixes for log4j (Log4Shell), jackson and kafka-clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,11 @@
         <encoding>UTF-8</encoding>
         <scala.maj.version>2.12</scala.maj.version>
         <scala.version>2.12.11</scala.version>
-        <kafka.version>3.7.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version>
         <flink.version>1.20.1</flink.version>
+        <jackson.version>2.22.2</jackson.version>
+        <log4j.version>2.26.1</log4j.version>
+        <embedded.kafka.version>3.9.2</embedded.kafka.version>
         <java.target.runtime>11</java.target.runtime>
         <jackson-jaxrs.version>1.9.13</jackson-jaxrs.version>
         <scoverage.plugin.version>1.4.0</scoverage.plugin.version>
@@ -47,6 +50,71 @@
             <url>http://scala-tools.org/repo-releases</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- transitives of connector-sdk-flink, pinned here until the SDK ships fixed versions -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-scala_${scala.maj.version}</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <!-- transitives of flink-connector-kafka; kept on the same jackson line as core/databind -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.20.0</version>
+            </dependency>
+            <!-- transitive of kafka-clients; kafka 3.9.2 uses the maintained at.yawk fork -->
+            <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.11.2</version>
+            </dependency>
+            <!-- test-scope only, via flink-runtime:tests; 1.8.1 is the last release of this artifact -->
+            <dependency>
+                <groupId>org.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.8.1</version>
+            </dependency>
+            <!-- transitive of embedded-postgres, test scope -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>42.7.13</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
 
@@ -88,7 +156,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.15.2</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -98,7 +166,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-            <version>2.12.7</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.sunbird.obsrv.connector</groupId>
@@ -116,7 +184,7 @@
         <dependency>
             <groupId>io.github.embeddedkafka</groupId>
             <artifactId>embedded-kafka_2.12</artifactId>
-            <version>3.4.0</version>
+            <version>${embedded.kafka.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
# kafka-connector — Vulnerability Fix Report

Tooling: **trivy** (fs + dependency tree), **gitleaks**, **checkov**. All changes are in `pom.xml`.

---

## 1. Summary

| Scan | Before | After |
|---|---|---|
| trivy fs — dependencies | **23** [2 CRIT, 8 HIGH, 13 MED] | **2** (no fix published, §4) |
| trivy fs — misconfigurations | 0 | 0 |
| trivy fs — secrets | 0 | 0 |
| gitleaks (tree + 39 commits of history) | 0 | 0 |
| checkov | 0 failed / 35 passed | 0 failed / 35 passed |

**The headline finding was Log4Shell** — `CVE-2021-44228` and `CVE-2021-45046`, both CRITICAL,
from `log4j-core` **2.14.1**.

Most of these arrive transitively through `connector-sdk-flink:2.0.0`, which still ships
log4j 2.14.1, jackson 2.15.2 and commons-lang3 3.12.0. They are pinned here via
`<dependencyManagement>` so this artifact is clean — but **the root fix belongs in the SDK**,
and every other consumer of it stays exposed until that lands.

---

## 2. Dependency changes

| Package | Was | Now | Clears |
|---|---|---|---|
| `log4j-api` / `log4j-core` / `log4j-slf4j-impl` | 2.14.1 | **2.26.1** | 2 CRITICAL + 6 others |
| `jackson-*` (6 modules) | 2.15.2 | **2.22.2** | 2 HIGH + 4 MED |
| `kafka-clients` | 3.7.1 | **3.9.2** | 1 HIGH + 2 MED |
| `commons-lang3` | 3.12.0 | **3.20.0** | CVE-2025-48924 |
| `postgresql` | 42.3.5 | **42.7.13** | CVE-2026-42198 |
| `at.yawk.lz4:lz4-java` | — | **1.11.2** | CVE-2026-59949 |
| `embedded-kafka` (test) | 3.4.0 | 3.9.2 | version match with kafka-clients |

Notes on the less obvious ones:

- **log4j 2.26.1, not 2.25.x.** `CVE-2026-49844` against `log4j-api` is only fixed in 2.25.5
  and 2.26.1.
- **jackson 2.22.2, not the 2.18 line.** 2.18.x does not carry fixes for `CVE-2026-54512`,
  `CVE-2026-54513`, `CVE-2026-54515` or `GHSA-r7wm-3cxj-wff9` — 2.21.4 is the actual floor.
  All six modules are pinned to one version deliberately: bumping only core and databind left
  `jackson-datatype-jsr310` and `jackson-datatype-jdk8` behind at 2.15.2 via
  `flink-connector-kafka`, i.e. a mixed-jackson classpath.
- **kafka-clients 3.9.2 changes the lz4 supplier.** It drops the abandoned
  `org.lz4:lz4-java` for the maintained `at.yawk.lz4` fork (same `net.jpountz` package),
  which is why the pin is against the fork.
- **postgresql is not really test-scope.** It reads as test-scope in `dependency:tree`, but
  530 `org/postgresql/` classes ship in the shaded jar. The pin is load-bearing.

---

## 3. Verification

Checked against the **built artifact**, not just the manifest — `trivy fs` on a fat jar
reports "0 language-specific files" and proves nothing, so the shipped versions were read out
of the jar's embedded `META-INF/maven/*/pom.properties`:

```
at.yawk.lz4:lz4-java:1.11.2
com.fasterxml.jackson.core:jackson-core:2.22.2
com.fasterxml.jackson.core:jackson-databind:2.22.2
com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.22.2
com.fasterxml.jackson.datatype:jackson-datatype-joda:2.22.2
com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22.2
org.apache.commons:commons-lang3:3.20.0
org.apache.logging.log4j:log4j-api:2.26.1
org.apache.logging.log4j:log4j-core:2.26.1
org.apache.logging.log4j:log4j-slf4j-impl:2.26.1
```

`mvn clean package` succeeds and produces both the shaded jar and the distribution tarball.

### Tests — please read

`KafkaConnectorTestSpec` **already fails on unmodified `main`**: `0 was not equal to 1` at
line 45, where `testSuccessEvents` sees no events. Reproduced 2/2 on a clean clone before any
edit, so it is pre-existing and not caused by these bumps.

After these changes it fails **identically** — same test, same assertion, same line, nothing
new. That is the regression gate used here. It is weaker than a green suite, and worth
flagging plainly: a passing suite was not available to gate against. Root cause not
investigated; the harness (`BaseFlinkSourceConnectorSpec`) lives in the connector-sdk-flink
test-jar, not this repo.

---

## 4. Remaining findings

| Finding | Why it stays |
|---|---|
| `CVE-2025-66566` (HIGH) and `CVE-2026-59949` (MED) on `org.lz4:lz4-java` | **No fixed version published** — the artifact is no longer maintained. Test-scope only (via `flink-runtime:tests`), absent from the shipped jar; the runtime path uses the `at.yawk` fork at 1.11.2. Pinned to 1.8.1 anyway, which clears the one fixable CVE in that group (`CVE-2025-12183`). |

---

## 5. Follow-up

`connector-sdk-flink` is the origin of the log4j and jackson exposure. These pins protect this
artifact only — the SDK repo should get the same pass so other connectors inherit the fix
rather than each pinning around it.
